### PR TITLE
fix(index.css pages): use https for rackspace logo

### DIFF
--- a/dist/css/index.css
+++ b/dist/css/index.css
@@ -15454,7 +15454,7 @@ header.site-header.site-header nav .navbar-brand {
     width: 170px;
 }
 header.site-header.site-header nav .navbar-brand a {
-    background: url("http://rackerlabs.github.io/canon/assets/logo-rackspace.png") center left no-repeat;
+    background: url("https://rackerlabs.github.io/canon/assets/logo-rackspace.png") center left no-repeat;
     /*background-size: 76%;*/
     width: 130px;
     height: 40px;

--- a/src/main/html/css/index.css
+++ b/src/main/html/css/index.css
@@ -15454,7 +15454,7 @@ header.site-header.site-header nav .navbar-brand {
     width: 170px;
 }
 header.site-header.site-header nav .navbar-brand a {
-    background: url("http://rackerlabs.github.io/canon/assets/logo-rackspace.png") center left no-repeat;
+    background: url("https://rackerlabs.github.io/canon/assets/logo-rackspace.png") center left no-repeat;
     /*background-size: 76%;*/
     width: 130px;
     height: 40px;


### PR DESCRIPTION
The browser gives warnings about "Mixed Content". These images can be
served up over https as well, so there's no reason to resort to http.
